### PR TITLE
Update log4j to 2.17 to address CVE-2021-45105

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ def versions = [
         hibernate          : '5.5.6.Final',
         logging            : '5.1.7',
         junit5             : '5.7.2',
-        log4JVersion       : '2.16.0'
+        log4JVersion       : '2.17.0'
  ]
 
 sourceSets {


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105