### PR TITLE
 Update the response code for get annotation set by non existent document id to 404

### DIFF
--- a/src/aat/java/uk/gov/hmcts/reform/em/annotation/functional/AnnotationSetScenarios.java
+++ b/src/aat/java/uk/gov/hmcts/reform/em/annotation/functional/AnnotationSetScenarios.java
@@ -119,13 +119,13 @@ public class AnnotationSetScenarios {
     }
 
     @Test
-    public void shouldReturn204WhenGetAnnotationSetNotFoundById() {
+    public void shouldReturn404WhenGetAnnotationSetNotFoundById() {
         final String annotationSetId = UUID.randomUUID().toString();
 
         request
                 .get("/api/annotation-sets/" + annotationSetId)
                 .then()
-                .statusCode(204)
+                .statusCode(404)
                 .log().all();
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/em/annotation/rest/AnnotationSetResource.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/annotation/rest/AnnotationSetResource.java
@@ -197,7 +197,7 @@ public class AnnotationSetResource {
     public ResponseEntity<AnnotationSetDTO> getAnnotationSet(@PathVariable UUID id) {
         log.debug("REST request to get AnnotationSet : {}", id);
         Optional<AnnotationSetDTO> annotationSetDTO = annotationSetService.findOne(id);
-        return ResponseUtil.wrapOrNoContent(annotationSetDTO);
+        return ResponseUtil.wrapOrNotFound(annotationSetDTO);
     }
 
     /**

--- a/src/test/java/uk/gov/hmcts/reform/em/annotation/rest/AnnotationSetResourceIntTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/annotation/rest/AnnotationSetResourceIntTest.java
@@ -162,7 +162,7 @@ public class AnnotationSetResourceIntTest extends BaseTest {
     public void getNonExistingAnnotationSet() throws Exception {
         // Get the annotationSet
         restLogoutMockMvc.perform(get("/api/annotation-sets/{id}", UUID.randomUUID()))
-            .andExpect(status().isNoContent());
+            .andExpect(status().isNotFound());
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EM-3548


### Change description ###
Update the response code for get annotation set by non existent document id - returns 204 but expected to return 404


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
