### PR TITLE
Revert "Bump flyway-core from 8.5.13 to 9.2.2"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ dependencies {
     implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.6.11'
     implementation group: 'com.google.guava', name: 'guava', version: '31.1-jre'
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
-    implementation group: 'org.flywaydb', name: 'flyway-core', version: '9.2.2'
+    implementation group: 'org.flywaydb', name: 'flyway-core', version: '8.5.13'
     implementation group: 'org.postgresql', name: 'postgresql', version: versions.postgresql
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
     implementation group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'


### PR DESCRIPTION
Reverts hmcts/em-annotation-api#938